### PR TITLE
chore: add Windows and macOS to CI matrix

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,12 +9,12 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [22.x, 20.x]
-        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
     - uses: actions/checkout@v4
@@ -22,7 +22,7 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
-        cache: 'npm'
+        cache: 'yarn'
     - run: yarn install
     - run: yarn run build
     - run: yarn test


### PR DESCRIPTION
## Summary
- CIのOSマトリクスに `windows-latest` と `macos-latest` を追加
- キャッシュ設定を `npm` から `yarn` に修正（実際のパッケージマネージャに合わせる）

## User Prompt
- CIにwinとmacを追加してPRで動作okまで修正

## Test plan
- [ ] ubuntu-latest + Node 20.x / 22.x でビルド・テスト通過
- [ ] windows-latest + Node 20.x / 22.x でビルド・テスト通過
- [ ] macos-latest + Node 20.x / 22.x でビルド・テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)