### PR TITLE
chore: rename package to @modernized/arxiv-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![npm version](https://badge.fury.io/js/arxiv-api-ts.svg)](https://badge.fury.io/js/arxiv-api-ts)
-# arXiv-api-ts
+[![npm version](https://badge.fury.io/js/@modernized%2Farxiv-api.svg)](https://badge.fury.io/js/@modernized%2Farxiv-api)
+# @modernized/arxiv-api
 
 A Javascript wrapper for the arXiv API.
 
@@ -8,18 +8,18 @@ A Javascript wrapper for the arXiv API.
 ### Installation
 
 ```sh
-npm i arxiv-api-ts
+npm i @modernized/arxiv-api
 
 # or
 
-yarn add arxiv-api-ts
+yarn add @modernized/arxiv-api
 ```
 
 ### Usage example
 
 #### Using async/await
 ```js
-import search from "arXiv-api-ts";
+import search from "@modernized/arxiv-api";
 
 const papers = await search({
 	searchQueryParams: [
@@ -40,7 +40,7 @@ console.log(papers);
 
 #### Using Promise
 ```js
-import search from "arXiv-api-ts";
+import search from "@modernized/arxiv-api";
 
 const papers = search({
 		searchQueryParams: [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "arxiv-api-ts",
+  "name": "@modernized/arxiv-api",
   "version": "1.1.0",
   "description": "node wrapper for arXiv api. typescript version",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Rename the npm package from `arxiv-api-ts` to `@modernized/arxiv-api`.

- `package.json` `name` field updated
- README badge URL, install commands, and import examples updated
- GitHub repo URLs in `package.json` (`repository`, `bugs`, `homepage`) intentionally kept — the GitHub repo itself is not being renamed

## Items to Confirm / Review

- **Lowercase package name.** The user originally requested `@modernized/arXiv-api` (uppercase X). npm registry rejects uppercase letters in new package names, so this PR uses `@modernized/arxiv-api` (all lowercase). Confirmed with the user before applying.
- **Scope ownership.** Publishing under `@modernized` requires owning that npm scope, or being a member of the `modernized` org. Verify before running `npm publish` / `/publish`.
- **Public scoped publish.** Scoped packages default to `private` on `npm publish` and will fail without a paid account. Either pass `--access public` or add `"publishConfig": { "access": "public" }` to `package.json` before publishing — not included in this PR since it wasn't part of the rename request.
- **Badge URL encoding.** Used `@modernized%2Farxiv-api` (percent-encoded `/`) for badge.fury.io, matching their scoped-package URL format. Will resolve once the package is actually published.
- **No version bump.** This rename will require publishing as a fresh package under the new name; the `1.1.0` version is unchanged. Decide whether to bump (e.g. to `2.0.0`) when publishing.

## User Prompt

> mainから派生して、@modernized/arXiv-api にパッケージ名をかえて。documentもみてね。
> main pullしてPR

## Implementation Notes

- Branched from latest `main` (`6c2a64a`)
- README updates: `[![npm version]...]` badge, `# arXiv-api-ts` heading → `# @modernized/arxiv-api`, `npm i` / `yarn add` install lines, both `import search from "arXiv-api-ts"` examples
- `yarn format`, `yarn lint`, `yarn build` all pass (one pre-existing `any` warning in `src/index.ts:39` is unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)