### PR TITLE
chore: prepare first publish under @modernized scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@modernized/arxiv-api",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "description": "node wrapper for arXiv api. typescript version",
   "main": "dist/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "test": "jest -u ./src/index.test.ts",
     "test:coverage": "jest ./dist/index.test.js --coverage",


### PR DESCRIPTION
## Summary

Prepare for the first npm publish of `@modernized/arxiv-api`.

- **Version reset**: `1.1.0` → `1.0.0`. The new scoped name is effectively a fresh package on the npm registry, so we start its history at `1.0.0` rather than inheriting the old `arxiv-api-ts@1.1.0` version line.
- **`publishConfig.access=public`**: scoped packages default to private on `npm publish`, which fails without a paid account. Adding this field once means future publishes don't have to remember `--access public`.

## Items to Confirm / Review

- **Version reset is intentional**: discussed with user — fresh package, fresh `1.0.0`. If you'd rather keep `1.1.0` for continuity, change it before merge.
- **Published artifact identity**: `@modernized/arxiv-api@1.0.0` will appear as a brand new package on the npm registry. No alias / deprecation set up against the old `arxiv-api-ts@1.1.0`.

## User Prompt

> mergeした。publish 初回。public

## Implementation Notes

- Branched from latest `main` (`d88d833`)
- `yarn lint` / `yarn build` pass (one pre-existing `any` warning in `src/index.ts:39` — unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)