### PR TITLE
chore: update repo URLs to modernized-js/arXiv-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/isamu/arXiv-api-ts.git"
+    "url": "git+https://github.com/modernized-js/arXiv-api.git"
   },
   "keywords": [
     "arxiv",
@@ -25,9 +25,9 @@
   "author": "elior avraham",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/isamu/arXiv-api-ts"
+    "url": "https://github.com/modernized-js/arXiv-api"
   },
-  "homepage": "https://github.com/isamu/arXiv-api-ts#readme",
+  "homepage": "https://github.com/modernized-js/arXiv-api#readme",
   "dependencies": {
     "fast-xml-parser": "^5.7.3"
   },


### PR DESCRIPTION
## Summary

Reflect the GitHub repo move (`isamu/arXiv-api-ts` → `modernized-js/arXiv-api`) in `package.json` metadata, so npm-registry links and `npm bug` / `npm repo` resolve to the new home.

- `repository.url`: `git+https://github.com/modernized-js/arXiv-api.git`
- `bugs.url`: `https://github.com/modernized-js/arXiv-api`
- `homepage`: `https://github.com/modernized-js/arXiv-api#readme`

The README needed no change — it only references the npm package name `@modernized/arxiv-api`, which is already correct.

## Items to Confirm / Review

- **Repo name vs package name**: GitHub repo is `arXiv-api` (mixed case), npm package is `@modernized/arxiv-api` (lowercase). That's intentional and matches what's already in main.
- **Local git remote**: I also updated my local `origin` to `git@github.com:modernized-js/arXiv-api.git` so this branch could be pushed. Other clones of the old URL will need the same `git remote set-url` (GitHub redirects work for fetch but emitting clean metadata wants the new URL).

## User Prompt

> https://github.com/modernized-js/arXiv-api-ts ここにレポジトリを引っ越した。gitの設定、package json/ readmeを更新して。
> modernized-js/arXiv-apiにrenameした。

## Implementation Notes

- Branched from latest `main` (`0231ced`)
- `yarn lint` / `yarn build` pass (one pre-existing `any` warning in `src/index.ts:39` — unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)